### PR TITLE
Add :accessors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ algo.flags_bitmask.set(:flag1, false)
 algo.flags_bitmask.get(:flag1) # false
 algo.flags_bitmask.get(:flag2) # true
 ```
+
+To add accessor methods for each flag (`flag1`/`flag1?`/`flag1=`) pass the option `:accessors => true`.

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -38,6 +38,19 @@ module BitmaskAttribute
         send(options[:bitmask_object])
       end
 
+      if options[:accessors]
+        options[:bit_ids].each do |attr|
+          define_method(attr) do
+            send(options[:bitmask_object])[attr]
+          end
+          alias_method "#{attr}?", attr
+
+          define_method("#{attr}=") do |value|
+            send(options[:bitmask_object])[attr] = value
+          end
+        end
+      end
+
     end
 
   end

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -13,7 +13,6 @@ module BitmaskAttribute
       }
       options = default_options.merge(options)
 
-      bitmask_obj = options[:bitmask_object]
       class_eval <<-ADD_METHODS
         def #{options[:bitmask_object]}
           @_#{options[:bitmask_object]} ||= Bitmask.new({

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -8,30 +8,35 @@ module BitmaskAttribute
 
     def bitmask_attribute ( attribute_name, options = {} )
       default_options = {
-        :bitmask_object => attribute_name.to_s + '_bitmask',
+        :bitmask_object => "#{attribute_name}_bitmask",
         :bit_ids => []
       }
       options = default_options.merge(options)
 
-      class_eval <<-ADD_METHODS
-        def #{options[:bitmask_object]}
-          @_#{options[:bitmask_object]} ||= Bitmask.new({
-            :bit_ids => #{options[:bit_ids].inspect},
-            :value => self.#{attribute_name},
-            :after_change => Proc.new { |bitmask|
-              self.#{attribute_name} = bitmask.value
-            }
-          })
+      define_method(options[:bitmask_object]) do
+        ivar_name = "@_#{options[:bitmask_object]}"
+        if instance_variable_defined?(ivar_name)
+          instance_variable_get(ivar_name)
+        else
+          instance_variable_set(ivar_name,
+            Bitmask.new(
+              :bit_ids => options[:bit_ids],
+              :value => send(attribute_name),
+              :after_change => Proc.new { |bitmask|
+                send("#{attribute_name}=", bitmask.value)
+              }
+            )
+          )
         end
+      end
 
-        def #{options[:bitmask_object]}= new_bitmask_hash
-          new_bitmask_hash.each do |key, val|
-            key = key.to_sym if #{options[:bitmask_object]}.string_bit_ids.include?(key)
-            #{options[:bitmask_object]}[key] = val
-          end
-          #{options[:bitmask_object]}
+      define_method("#{options[:bitmask_object]}=") do |new_bitmask_hash|
+        new_bitmask_hash.each do |key, val|
+          key = key.to_sym if send(options[:bitmask_object]).string_bit_ids.include?(key)
+          send(options[:bitmask_object])[key] = val
         end
-      ADD_METHODS
+        send(options[:bitmask_object])
+      end
 
     end
 

--- a/test/test_bitmask_attribute_accessors.rb
+++ b/test/test_bitmask_attribute_accessors.rb
@@ -1,0 +1,21 @@
+require File.dirname(__FILE__) + '/test_helper.rb'
+
+class TestBitmaskAttributeAccessors < Test::Unit::TestCase
+  class Something
+    attr_accessor :flags
+    include BitmaskAttribute
+    bitmask_attribute :flags,
+      :bit_ids => [:flag1, :flag2],
+      :accessors => true
+  end
+
+  def test_accessors
+    @something = Something.new
+    @something.flag1 = true
+    assert @something.flags == 1
+    assert @something.flag1
+    assert @something.flag1?
+    assert !@something.flag2
+    assert !@something.flag2?
+  end
+end


### PR DESCRIPTION
To add accessor methods for each flag (`flag1`/`flag1=`, etc.) pass the option `:accessors => true`.

We've been using these convenience methods for a while and I'm extracting it into the `aukan-bitmask` gem.
