### PR TITLE
Integrate with ActiveRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,17 @@ algo.flags_bitmask.get(:flag2) # true
 ```
 
 To add accessor methods for each flag (`flag1`/`flag1?`/`flag1=`) pass the option `:accessors => true`.
+
+# ActiveRecord Integration
+
+If ActiveRecord is loaded, the "dirty" methods are emulated for the bitmask object:
+
+- `flags_bitmask_changed?`
+- `flags_bitmask_was`
+
+If :accessors is enabled, they are emulated for each attribute:
+
+- `flag1_changed?`
+- `flag1_was`
+
+ActiveRecord typecasting is used when setting values: common strings found in web forms like `"1"`/`"0"` convert to `true`/`false` respectively.

--- a/lib/bitmask.rb
+++ b/lib/bitmask.rb
@@ -36,7 +36,7 @@ class Bitmask
       raise ArgumentError, "#{bit_id.inspect} was not included on bit_ids array"
     end
 
-    if val == true
+    if val
       self.value |= (2 ** position)
     else
       self.value &= ~(2 ** position)

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -51,6 +51,34 @@ module BitmaskAttribute
         end
       end
 
+      if defined?(::ActiveRecord)
+        # Emulate ActiveRecord dirty methods
+        define_method("#{options[:bitmask_object]}_was") do
+          Bitmask.new(
+            :bit_ids => options[:bit_ids],
+            :value => send("#{attribute_name}_was")
+          )
+        end
+
+        define_method("#{options[:bitmask_object]}_changed?") do
+          send("#{attribute_name}_changed?")
+        end
+
+        if options[:accessors]
+          options[:bit_ids].each do |attr|
+            # Emulate ActiveRecord dirty methods for every attribute
+            define_method("#{attr}_was") do
+              send("#{options[:bitmask_object]}_was")[attr]
+            end
+
+            define_method("#{attr}_changed?") do
+              send("#{attribute_name}_changed?") &&
+                send("#{attr}_was") != send(attr)
+            end
+          end
+        end
+      end
+
     end
 
   end

--- a/test/test_active_record.rb
+++ b/test/test_active_record.rb
@@ -1,0 +1,87 @@
+require File.dirname(__FILE__) + '/test_helper.rb'
+
+class TestActiveRecord < Test::Unit::TestCase
+
+  ::ActiveRecord = :active_record_stub
+
+  module StubActiveRecord
+    def flags_was
+      1
+    end
+
+    def flags_changed?
+      flags != flags_was
+    end
+  end
+
+  class WithActiveRecord
+    include StubActiveRecord
+    include BitmaskAttribute
+    attr_accessor :flags
+    bitmask_attribute :flags,
+      :bit_ids => [:flag1, :flag2, :flag3]
+  end
+
+  class WithActiveRecordAndAccessors
+    include StubActiveRecord
+    include BitmaskAttribute
+    attr_accessor :flags
+    bitmask_attribute :flags,
+      :bit_ids => [:flag1, :flag2, :flag3],
+      :accessors => true
+  end
+
+  # remove the stub so we don't affect other tests
+  Object.send(:remove_const, :ActiveRecord)
+
+  def test_attribute_was
+    @something = WithActiveRecord.new
+    assert_equal(1, @something.flags_bitmask_was.value)
+    assert_equal([:flag1, :flag2, :flag3], @something.flags_bitmask_was.bit_ids)
+  end
+
+  def test_attribute_changed
+    @something = WithActiveRecord.new
+    @something.flags = 0
+    assert @something.flags_bitmask_changed?
+    @something.flags = 1
+    assert !@something.flags_bitmask_changed?
+  end
+
+  def test_accessor_attribute_was
+    @something = WithActiveRecordAndAccessors.new
+    assert @something.flag1_was
+    assert !@something.flag2_was
+    assert !@something.flag3_was
+  end
+
+  def test_accessor_attribute_changed
+    @something = WithActiveRecordAndAccessors.new
+    @something.flags = 0
+    assert @something.flag1_changed?
+    assert !@something.flag2_changed?
+    assert !@something.flag3_changed?
+  end
+
+  def test_typecast
+    Object.const_set(:ActiveRecord, Module.new)
+    ::ActiveRecord.const_set("VERSION", Module.new)
+    ::ActiveRecord::VERSION.const_set("MAJOR", 4)
+    ::ActiveRecord.const_set("Type", Module.new)
+    active_record_boolean = Class.new do
+      def type_cast_from_user(val)
+        val == "1"
+      end
+    end
+    ::ActiveRecord::Type.const_set("Boolean", active_record_boolean)
+    @something = WithActiveRecordAndAccessors.new
+    assert !@something.flag1
+    @something.flag1 = "1"
+    @something.flag2 = "0"
+    assert @something.flag1
+    assert !@something.flag2
+  ensure
+    # remove the stub so we don't affect other tests
+    Object.send(:remove_const, :ActiveRecord)
+  end
+end


### PR DESCRIPTION
- Emulate dirty methods: `attribute_was` and `attribute_changed?`
- Typecast values when setting: strings like `"1"`/`"0"` translate to `true`/`false` respectively. ActiveRecord versions 3-5 supported.

We already emulate these methods in our Rails code and I'm extracting it into the gem. Dependent on PR #1.
